### PR TITLE
Unmarshal/required tag

### DIFF
--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -30,7 +30,6 @@ func Parse(tokens Tokens, v interface{}) error {
 type parser struct {
 	tokens Tokens
 	index  int
-	tags   map[string]int
 	obj    reflect.Value
 }
 
@@ -169,14 +168,18 @@ func (p *parser) parsePointerObject(vo reflect.Value) (int, error) {
 }
 
 func (p *parser) parseStructure(vo reflect.Value) (int, error) {
-	p.tags = getFieldTags(vo)
+	tags, err := getFieldTags(vo)
+	if err != nil {
+		return -1, err
+	}
 	if vo.Kind() == reflect.Ptr {
 		return p.parsePointerObject(vo)
 	}
+	// TODO : Check for required fields somehow??? :grimacing:
 
 	for p.next() {
 		if p.current().Value == ":" {
-			obj := vo.Field(p.tags[p.previous().Value])
+			obj := vo.Field(tags[p.previous().Value].FieldIndex)
 			val, err := p.parse(obj)
 			if err != nil {
 				panic(err)

--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -175,23 +175,23 @@ func (p *parser) parseStructure(vo reflect.Value) (int, error) {
 	if vo.Kind() == reflect.Ptr {
 		return p.parsePointerObject(vo)
 	}
-	// TODO : Check for required fields somehow??? :grimacing:
-
 	for p.next() {
 		if p.current().Value == ":" {
-			obj := vo.Field(tags[p.previous().Value].FieldIndex)
+			tag := tags[p.previous().Value]
+			obj := vo.Field(tag.FieldIndex)
 			val, err := p.parse(obj)
 			if err != nil {
 				panic(err)
 			}
+			tags.Set(tag)
 			obj.Set(val)
 		}
 		if p.eof() || p.current().Type == ClosingCurlyToken {
 			p.next()
-			return p.index, nil
+			return p.index, tags.CheckRequired()
 		}
 	}
-	return p.index, nil
+	return p.index, tags.CheckRequired()
 }
 
 func getReflectValue(v interface{}) reflect.Value {

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -15,7 +15,7 @@ type Ding struct {
 	Boolean        bool
 	Dong           string
 	Float          float64
-	Object         *TestObject  `json:"object"`
+	Object         *TestObject  `json:"object,required"`
 	Array          []int64      `json:"array"`
 	StringSlice    []string     `json:"string_slice"`
 	MultiDimension [][]int      `json:"multi_dimension"`

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -2,7 +2,6 @@ package json
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 )
 
@@ -15,7 +14,7 @@ type Ding struct {
 	Boolean        bool
 	Dong           string
 	Float          float64
-	Object         *TestObject  `json:"object,required"`
+	Object         *TestObject  `json:"object"`
 	Array          []int64      `json:"array"`
 	StringSlice    []string     `json:"string_slice"`
 	MultiDimension [][]int      `json:"multi_dimension"`
@@ -354,7 +353,6 @@ func TestParsePointer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Println(ding)
 	if ding.Object.Name != "lasse" {
 		t.Fatal("oh no")
 	}
@@ -368,7 +366,6 @@ func TestParseInterfaceString(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Println(ding)
 	if ding.(string) != "lasse" {
 		t.Fatal("oh no")
 	}
@@ -390,6 +387,21 @@ func TestMapFollowedBy(t *testing.T) {
 		ding.MapObject["lumber"] != 13 ||
 		ding.Float != 3.2 {
 		t.Fatal("Unexpected result:", ding)
+	}
+}
+
+func TestRequiredFields(t *testing.T) {
+	type RequiredBoi struct {
+		Name string `json:"name,required"`
+	}
+
+	var r RequiredBoi
+	if err := Parse(Lex(`{}`), &r); !IsRequiredErr(err) {
+		t.Fatal("no required error, or unexpected error returned:", err)
+	}
+
+	if err := Parse(Lex(`{"name": "lasse"}`), &r); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/json/tags_test.go
+++ b/pkg/json/tags_test.go
@@ -8,20 +8,37 @@ import (
 type TagTest struct {
 	Name     string
 	DingDong string
+	Age      int64 `json:"age,required"`
 }
 
 func TestTagFormatting(t *testing.T) {
 	v := reflect.ValueOf(TagTest{
 		Name:     "lasse",
 		DingDong: "ding_dong",
+		Age:      30,
 	})
-	tags := getFieldTags(v)
+	tags, err := getFieldTags(v)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, ok := tags["name"]; !ok {
 		t.Fatal(`could not find "name" tag`)
 	}
 
-	if _, ok := tags["ding_dong"]; !ok {
+	dingDong, ok := tags["ding_dong"]
+	if !ok {
 		t.Fatal(`could not find "ding_dong" tag`)
+	}
+	if dingDong.FieldIndex != 1 {
+		t.Fatal("unexpected field_index for ding_dong:", dingDong.FieldIndex)
+	}
+
+	age, ok := tags["age"]
+	if !ok {
+		t.Fatal(`could not find "age" tag`)
+	}
+	if age.FieldIndex != 2 {
+		t.Fatal("unexpected field_index for age:", age.FieldIndex)
 	}
 }
 

--- a/samples/main.go
+++ b/samples/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/Pungyeon/json-validation/pkg/required"
 )
 
@@ -38,5 +36,4 @@ func main() {
 	if err := required.Unmarshal(jsonBytes, &customer); err != nil {
 		panic(err)
 	}
-	fmt.Println(customer)
 }


### PR DESCRIPTION
closing #12 

Implementing tags for required fields. Enabling developers to write the following tag:

```go
type Struct struct {
    Name string `json:"name,required"`
}
```

This will ensure that the field "Name" is populated by the given JSON. 

So parsing this JSON will fail: `{}`

Where as this will be accepted: `{"name": "lasse"}`