### PR TITLE
Lexer stream

### DIFF
--- a/article/required/required.go
+++ b/article/required/required.go
@@ -16,7 +16,7 @@ func ReturnIfError(errs ...error) error {
 	return nil
 }
 
-// Unmarshal is a wrapping function of the json.Unmarshal function
+// Unmarshal is a wrapping function of the json.UnmarshalInterface function
 func Unmarshal(data []byte, v interface{}) error {
 	return ReturnIfError(
 		json.Unmarshal(data, v),

--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -166,9 +166,6 @@ func (p *parser) decodeArray(arr reflect.Value) error {
 		case token.Comma:
 			continue // skip commas
 		case token.ClosingBrace:
-			if arr.Len() == i {
-				return nil
-			}
 			arr.Set(arr.Slice(0, i))
 			return nil
 		case token.OpenCurly:
@@ -178,9 +175,6 @@ func (p *parser) decodeArray(arr reflect.Value) error {
 			}
 			i++
 			if p.current().Type == token.ClosingBrace {
-				if arr.Len() == i {
-					return nil
-				}
 				arr.Set(arr.Slice(0, i))
 				return nil
 			}

--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -31,7 +31,7 @@ func (p *parser) decode(val reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	if tags[structtag.UnmarshalInterfaceKey].Required {
+	if tags.UnmarshalInterface {
 		if val.CanAddr() {
 			str := p.lexer.SkipValue()
 			return val.Addr().Interface().(json.Unmarshaler).UnmarshalJSON(str)
@@ -44,7 +44,7 @@ func (p *parser) decode(val reflect.Value) error {
 		return err
 	}
 
-	if tags[structtag.RequiredInterfaceKey].Required {
+	if tags.RequiredInterface {
 		if val.CanAddr() {
 			return val.Addr().Interface().(required.Required).IsValueValid()
 		} else {
@@ -102,7 +102,7 @@ func (p *parser) _decode(val reflect.Value, tags structtag.Tags) error {
 func (p *parser) decodeObject(val reflect.Value, tags structtag.Tags) error {
 	for p.next() {
 		if p.current().Type == token.Colon {
-			tag := tags[p.previous().ToString()]
+			tag := tags.Tags[p.previous().ToString()]
 			if err := p.decode(val.Field(tag.FieldIndex)); err != nil {
 				return err
 			}
@@ -321,7 +321,7 @@ func (p *parser) parseStructure(vo reflect.Value) error {
 	}
 	for p.next() {
 		if p.current().Type == token.Colon {
-			tag := tags[p.previous().ToString()]
+			tag := tags.Tags[p.previous().ToString()]
 			obj := vo.Field(tag.FieldIndex)
 			if !obj.CanSet() { // Private values may not be set.
 				continue

--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -167,7 +167,7 @@ func (p *parser) parseStructure(vo reflect.Value) error {
 	}
 	for p.next() {
 		if p.current().Type == token.Colon {
-			tag := tags[p.previous().Value.(string)]
+			tag := tags[p.previous().ToString()]
 			obj := vo.Field(tag.FieldIndex)
 			if !obj.CanSet() { // Private values may not be set.
 				continue
@@ -228,7 +228,7 @@ func (p *parser) parseField() (reflect.Value, error) {
 	for p.next() {
 		if p.current().Type == token.Colon {
 			val := reflect.New(token.ReflectTypeString).Elem()
-			val.SetString(p.previous().Value.(string))
+			val.SetString(p.previous().ToString())
 			return val, nil
 		}
 	}

--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Pungyeon/required/pkg/token"
 )
 
-func Parse(l lexer.Lexer, v interface{}) error {
+func Parse(l *lexer.Lexer, v interface{}) error {
 	vo := getReflectValue(v)
 	obj, err := (&parser{lexer: l}).parse(vo)
 	if err != nil {
@@ -22,7 +22,7 @@ func Parse(l lexer.Lexer, v interface{}) error {
 }
 
 type parser struct {
-	lexer lexer.Lexer
+	lexer *lexer.Lexer
 	obj   reflect.Value
 }
 

--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -154,6 +154,9 @@ func (p *parser) parseStructure(vo reflect.Value) error {
 		if p.current().Type == token.Colon {
 			tag := tags[p.previous().Value.(string)]
 			obj := vo.Field(tag.FieldIndex)
+			if !obj.CanSet() { // Private values may not be set.
+				continue
+			}
 			val, err := p.parse(obj)
 			if err != nil {
 				return err

--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -31,12 +31,10 @@ type parser struct {
 
 func (p *parser) previous() token.Token {
 	return p.lexer.Previous()
-	//return p.tokens[p.index-1]
 }
 
 func (p *parser) current() token.Token {
 	return p.lexer.Current()
-	//return p.tokens[p.index]
 }
 
 func (p *parser) eof() bool {
@@ -68,16 +66,8 @@ func (p *parser) parseObject(vo reflect.Value) (reflect.Value, error) {
 	if kind == reflect.Map {
 		return p.parseMap(_type)
 	}
-	return p.parseStructureWithCopy(vo)
-}
-
-func (p *parser) parseStructureWithCopy(vo reflect.Value) (reflect.Value, error) {
-	_, err := p.copy().parseStructure(vo)
-	if err != nil {
-		return vo, err
-	}
-	//p.index = index
-	return vo, nil
+	_, err := p.parseStructure(vo)
+	return vo, err
 }
 
 func determineObjectType(vo reflect.Value) (reflect.Kind, reflect.Type) {
@@ -107,11 +97,10 @@ func (p *parser) parseArray(sliceType reflect.Type) (reflect.Value, error) {
 			return p.setArray(sliceType, slice)
 		case token.OpenCurly:
 			obj := reflect.New(sliceType.Elem()).Elem()
-			_, err := p.copy().parseStructure(obj)
+			_, err := p.parseStructure(obj)
 			if err != nil {
 				return obj, nil
 			}
-			//p.index = index
 			slice = append(slice, obj)
 			if p.current().Type == token.ClosingBrace {
 				return p.setArray(sliceType, slice)
@@ -142,14 +131,6 @@ func (p *parser) setArray(sliceType reflect.Type, slice []reflect.Value) (reflec
 	return arr, nil
 }
 
-func (p *parser) copy() *parser {
-	return &parser{
-		lexer: p.lexer,
-		//index:  p.index,
-		//tokens: p.tokens,
-	}
-}
-
 func getValueOfPointer(vo reflect.Value) reflect.Value {
 	ptr := reflect.New(vo.Type())
 	p2 := ptr.Elem()
@@ -159,7 +140,7 @@ func getValueOfPointer(vo reflect.Value) reflect.Value {
 
 func (p *parser) parsePointerObject(vo reflect.Value) (int, error) {
 	ptr := getValueOfPointer(vo)
-	index, err := p.copy().parseStructure(getElemOfValue(ptr))
+	index, err := p.parseStructure(getElemOfValue(ptr))
 	if err != nil {
 		return index, err
 	}

--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -151,8 +151,8 @@ func (p *parser) parseStructure(vo reflect.Value) error {
 		return p.parsePointerObject(vo)
 	}
 	for p.next() {
-		if p.current().Value == ":" {
-			tag := tags[p.previous().Value]
+		if p.current().Type == token.Colon {
+			tag := tags[p.previous().Value.(string)]
 			obj := vo.Field(tag.FieldIndex)
 			val, err := p.parse(obj)
 			if err != nil {
@@ -209,7 +209,7 @@ func (p *parser) parseField() (reflect.Value, error) {
 	for p.next() {
 		if p.current().Type == token.Colon {
 			val := reflect.New(token.ReflectTypeString).Elem()
-			val.SetString(p.previous().Value)
+			val.SetString(p.previous().Value.(string))
 			return val, nil
 		}
 	}

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -3,8 +3,6 @@ package json
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"reflect"
 	"regexp"
 	"testing"
 
@@ -163,7 +161,7 @@ func TestParseMultiArray(t *testing.T) {
 	}
 
 	if len(obj) != 2 {
-		t.Fatal("length of object:", len(obj))
+		t.Fatal("length of object:", len(obj), obj)
 	}
 
 	if len(obj[0]) != 3 {
@@ -221,7 +219,7 @@ func TestParseObjectArray(t *testing.T) {
 	}
 
 	if len(obj) != 2 {
-		t.Fatal("length of object:", len(obj))
+		t.Fatal("length of object:", len(obj), obj)
 	}
 
 	if obj[1].Name != "basse" {
@@ -478,10 +476,4 @@ func BenchmarkPkgUnmarshal(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
-}
-
-func TestReflectSlices(t *testing.T) {
-	arr := reflect.MakeSlice(reflect.TypeOf([]int{}), 0, 10)
-	arr = insertAt(arr, 0, reflect.ValueOf(2))
-	fmt.Println(arr.Index(0))
 }

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -58,12 +58,12 @@ func LexString(t *testing.T, input string) *lexer.Lexer {
 
 type PrivateFields struct {
 	ding string
+	dong TestObject
 }
 
 func TestPrivateFields(t *testing.T) {
-	t.Skip()
 	var pf PrivateFields
-	if err := Parse(LexString(t, `{"ding": "dingeling"}`), &pf); err != nil {
+	if err := Parse(LexString(t, `{"ding": "dingeling", "dong": {"name": "lasse"}}`), &pf); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -3,8 +3,10 @@ package json
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/Pungyeon/required/pkg/lexer"
 	"github.com/Pungyeon/required/pkg/structtag"
@@ -498,15 +500,23 @@ func BenchmarkPkgUnmarshal(b *testing.B) {
 	}
 }
 
-type InterfaceType struct {
-	Value interface{}
+type DateType struct {
+	Value time.Time
 }
 
-var interfaceSample = []byte(`{
-	"value": {
-		"float": 3.2	
-	}
+var dateSample = []byte(`{
+	"value": "2010-08-12"	
 }`)
+
+func TestDate(t *testing.T) {
+
+	var d DateType
+	if err := Parse(lexer.NewLexer(dateSample), &d); err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(d.Value)
+}
 
 //func BenchmarkInterfaceUnmarshalStd(b *testing.B) {
 //	for i := 0; i < b.N; i++ {

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -481,15 +481,7 @@ func BenchmarkPkgUnmarshal(b *testing.B) {
 }
 
 func TestReflectSlices(t *testing.T) {
-	arr := reflect.MakeSlice(reflect.TypeOf([]int{}), 0, 0)
-	arr = reflect.Append(arr, reflect.ValueOf(2))
-
+	arr := reflect.MakeSlice(reflect.TypeOf([]int{}), 0, 10)
+	arr = insertAt(arr, 0, reflect.ValueOf(2))
 	fmt.Println(arr.Index(0))
-
-	//v := reflect.ValueOf(&d)
-	//v.Set(arr)
-	//
-	//if d[0] != 2 {
-	//	t.Fatal(d[0])
-	//}
 }

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -52,7 +52,7 @@ var sample = `{
 	}`
 
 func LexString(t *testing.T, input string) *lexer.Lexer {
-	return lexer.NewLexer(input)
+	return lexer.NewLexer([]byte(input))
 }
 
 type PrivateFields struct {

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -52,12 +52,18 @@ var sample = `{
 	}`
 
 func LexString(t *testing.T, input string) *lexer.Lexer {
-	//tokens, err := lexer.Lex(input)
-	//if err != nil {
-	//	t.Fatal(err)
-	//}
-	//return tokens
 	return lexer.NewLexer(input)
+}
+
+type PrivateFields struct {
+	ding string
+}
+
+func TestPrivateFields(t *testing.T) {
+	var pf PrivateFields
+	if err := Parse(LexString(t, `{"ding": "dingeling"}`), &pf); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestParserSimple(t *testing.T) {

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -77,23 +77,23 @@ func TestParserSimple(t *testing.T) {
 	}
 }
 
-func TestParserOptimised(t *testing.T) {
-	var d Ding
-	if err := Decode(LexString(t, sample), &d); err != nil {
+func TestParseSample(t *testing.T) {
+	var ding Ding
+	if err := Parse(LexString(t, sample), &ding); err != nil {
 		t.Fatal(err)
 	}
-
-	if d.Ding != 1 ||
-		d.Object == nil ||
-		d.Object.Name != "lasse" ||
-		len(d.Array) != 3 || d.Array[0] != 1 ||
-		len(d.MultiDimension[0]) != 3 || d.MultiDimension[1][2] != 6 ||
-		len(d.ObjectArray) != 2 || d.ObjectArray[0].Name != "lasse" ||
-		d.Float != 3.2 ||
-		d.MapObject["lumber"] != 13 {
-		t.Fatal(d)
+	if !(ding.Ding == 1 &&
+		ding.Dong == "hello" &&
+		ding.Boolean == true &&
+		ding.Object.Name == "lasse" &&
+		ding.Array[2] == 3 &&
+		ding.StringSlice[2] == "3" &&
+		ding.MultiDimension[1][2] == 6 &&
+		ding.ObjectArray[1].Name == "basse" &&
+		ding.MapObject["lumber"] == 13 &&
+		ding.Float == 3.2) {
+		t.Fatal(ding)
 	}
-
 }
 
 func TestParsePrimitive(t *testing.T) {
@@ -497,3 +497,31 @@ func BenchmarkPkgUnmarshal(b *testing.B) {
 		}
 	}
 }
+
+type InterfaceType struct {
+	Value interface{}
+}
+
+var interfaceSample = []byte(`{
+	"value": {
+		"float": 3.2	
+	}
+}`)
+
+//func BenchmarkInterfaceUnmarshalStd(b *testing.B) {
+//	for i := 0; i < b.N; i++ {
+//		var ding map[string]int
+//		if err := json.Unmarshal([]byte(`{ "one": 1, "two": 2, "three": 3 }`), &ding); err != nil {
+//			b.Fatal(err)
+//		}
+//	}
+//}
+//
+//func BenchmarkInterfaceUnmarshalPkg(b *testing.B) {
+//	for i := 0; i < b.N; i++ {
+//		var ding map[string]int
+//		if err := Unmarshal([]byte(`{ "one": 1, "two": 2, "three": 3 }`), &ding); err != nil {
+//			b.Fatal(err)
+//		}
+//	}
+//}

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -3,6 +3,8 @@ package json
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -476,4 +478,18 @@ func BenchmarkPkgUnmarshal(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestReflectSlices(t *testing.T) {
+	arr := reflect.MakeSlice(reflect.TypeOf([]int{}), 0, 0)
+	arr = reflect.Append(arr, reflect.ValueOf(2))
+
+	fmt.Println(arr.Index(0))
+
+	//v := reflect.ValueOf(&d)
+	//v.Set(arr)
+	//
+	//if d[0] != 2 {
+	//	t.Fatal(d[0])
+	//}
 }

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -60,6 +60,7 @@ type PrivateFields struct {
 }
 
 func TestPrivateFields(t *testing.T) {
+	t.Skip()
 	var pf PrivateFields
 	if err := Parse(LexString(t, `{"ding": "dingeling"}`), &pf); err != nil {
 		t.Fatal(err)
@@ -74,6 +75,25 @@ func TestParserSimple(t *testing.T) {
 	if obj.Name != "lasse" {
 		t.Fatal("not lasse:", obj.Name)
 	}
+}
+
+func TestParserOptimised(t *testing.T) {
+	var d Ding
+	if err := Decode(LexString(t, sample), &d); err != nil {
+		t.Fatal(err)
+	}
+
+	if d.Ding != 1 ||
+		d.Object == nil ||
+		d.Object.Name != "lasse" ||
+		len(d.Array) != 3 || d.Array[0] != 1 ||
+		len(d.MultiDimension[0]) != 3 || d.MultiDimension[1][2] != 6 ||
+		len(d.ObjectArray) != 2 || d.ObjectArray[0].Name != "lasse" ||
+		d.Float != 3.2 ||
+		d.MapObject["lumber"] != 13 {
+		t.Fatal(d)
+	}
+
 }
 
 func TestParsePrimitive(t *testing.T) {
@@ -304,17 +324,17 @@ func TestParseAsReflectValue(t *testing.T) {
 			testParse(t, LexString(t, `{"name": "lasse"}`), &v)
 			return v.Name == "lasse"
 		}},
-		{name: "array", check: func() bool {
+		{name: "string_array", check: func() bool {
 			var v []string
 			testParse(t, LexString(t, `["name", "lasse"]`), &v)
 			return v[1] == "lasse"
 		}},
-		{name: "array", check: func() bool {
+		{name: "interface_string", check: func() bool {
 			var v interface{}
 			testParse(t, LexString(t, `"lasse"`), &v)
 			return v.(string) == "lasse"
 		}},
-		{name: "array", check: func() bool {
+		{name: "interface_object", check: func() bool {
 			var v interface{}
 			testParse(t, LexString(t, `{"name": "lasse"}`), &v)
 			return v.(map[string]interface{})["name"] == "lasse"

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -51,7 +51,7 @@ var sample = `{
 		"float": 3.2
 	}`
 
-func LexString(t *testing.T, input string) lexer.Lexer {
+func LexString(t *testing.T, input string) *lexer.Lexer {
 	//tokens, err := lexer.Lex(input)
 	//if err != nil {
 	//	t.Fatal(err)
@@ -251,7 +251,7 @@ func TestMapStringStringUnmarshal(t *testing.T) {
 	}
 }
 
-func testParse(t *testing.T, lexer lexer.Lexer, v interface{}) {
+func testParse(t *testing.T, lexer *lexer.Lexer, v interface{}) {
 	if err := Parse(lexer, v); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Pungyeon/required/pkg/lexer"
 	"github.com/Pungyeon/required/pkg/structtag"
-	"github.com/Pungyeon/required/pkg/token"
 )
 
 type TestObject struct {
@@ -52,12 +51,13 @@ var sample = `{
 		"float": 3.2
 	}`
 
-func LexString(t *testing.T, input string) token.Tokens {
-	tokens, err := lexer.Lex(input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return tokens
+func LexString(t *testing.T, input string) lexer.Lexer {
+	//tokens, err := lexer.Lex(input)
+	//if err != nil {
+	//	t.Fatal(err)
+	//}
+	//return tokens
+	return lexer.NewLexer(input)
 }
 
 func TestParserSimple(t *testing.T) {
@@ -102,9 +102,9 @@ func TestParseArrayInStruct(t *testing.T) {
 
 func TestParseArray(t *testing.T) {
 	tokens := LexString(t, "[1, 2, 3, 4]")
-	if tokens.Join(";") != "[;1;,;2;,;3;,;4;]" {
-		t.Fatal("oh no", tokens.Join(";"))
-	}
+	//if tokens.Join(";") != "[;1;,;2;,;3;,;4;]" {
+	//	t.Fatal("oh no", tokens.Join(";"))
+	//}
 
 	var obj []int
 	if err := Parse(tokens, &obj); err != nil {
@@ -122,9 +122,9 @@ func TestParseArray(t *testing.T) {
 
 func TestParseFloatArray(t *testing.T) {
 	tokens := LexString(t, "[1.1, 2.2, 3.3, 4.4]")
-	if tokens.Join(";") != "[;1.1;,;2.2;,;3.3;,;4.4;]" {
-		t.Fatal("oh no", tokens.Join(";"))
-	}
+	//if tokens.Join(";") != "[;1.1;,;2.2;,;3.3;,;4.4;]" {
+	//	t.Fatal("oh no", tokens.Join(";"))
+	//}
 
 	var obj []float64
 	if err := Parse(tokens, &obj); err != nil {
@@ -145,9 +145,9 @@ func TestParseMultiArray(t *testing.T) {
 	[1, 2, 3],
 	[4, 5, 6]
 ]`)
-	if tokens.Join(";") != "[;[;1;,;2;,;3;];,;[;4;,;5;,;6;];]" {
-		t.Fatal("oh no", tokens.Join(";"))
-	}
+	//if tokens.Join(";") != "[;[;1;,;2;,;3;];,;[;4;,;5;,;6;];]" {
+	//	t.Fatal("oh no", tokens.Join(";"))
+	//}
 
 	var obj [][]int
 	if err := Parse(tokens, &obj); err != nil {
@@ -172,9 +172,9 @@ func TestParseMultiStringArray(t *testing.T) {
 	["1", "2", "3"],
 	["4", "5", "6"]
 ]`)
-	if tokens.Join(";") != "[;[;1;,;2;,;3;];,;[;4;,;5;,;6;];]" {
-		t.Fatal("oh no", tokens.Join(";"))
-	}
+	//if tokens.Join(";") != "[;[;1;,;2;,;3;];,;[;4;,;5;,;6;];]" {
+	//	t.Fatal("oh no", tokens.Join(";"))
+	//}
 
 	var obj [][]string
 	if err := Parse(tokens, &obj); err != nil {
@@ -203,9 +203,9 @@ func TestParseObjectArray(t *testing.T) {
 		"name": "basse"
 	}
 ]`)
-	if tokens.Join(";") != "[;{;name;:;lasse;};,;{;name;:;basse;};]" {
-		t.Fatal("oh no", tokens.Join(";"))
-	}
+	//if tokens.Join(";") != "[;{;name;:;lasse;};,;{;name;:;basse;};]" {
+	//	t.Fatal("oh no", tokens.Join(";"))
+	//}
 
 	var obj []TestObject
 	if err := Parse(tokens, &obj); err != nil {
@@ -251,8 +251,8 @@ func TestMapStringStringUnmarshal(t *testing.T) {
 	}
 }
 
-func testParse(t *testing.T, tokens token.Tokens, v interface{}) {
-	if err := Parse(tokens, v); err != nil {
+func testParse(t *testing.T, lexer lexer.Lexer, v interface{}) {
+	if err := Parse(lexer, v); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/json/unmarshal.go
+++ b/pkg/json/unmarshal.go
@@ -9,3 +9,7 @@ func Unmarshal(data []byte, v interface{}) error {
 	//}
 	return Parse(lexer.NewLexer(data), v)
 }
+
+func DecodeJSON(data []byte, v interface{}) error {
+	return Decode(lexer.NewLexer(data), v)
+}

--- a/pkg/json/unmarshal.go
+++ b/pkg/json/unmarshal.go
@@ -7,5 +7,5 @@ func Unmarshal(data []byte, v interface{}) error {
 	//if err != nil {
 	//	return err
 	//}
-	return Parse(lexer.NewLexer(string(data)), v)
+	return Parse(lexer.NewLexer(data), v)
 }

--- a/pkg/json/unmarshal.go
+++ b/pkg/json/unmarshal.go
@@ -3,9 +3,9 @@ package json
 import "github.com/Pungyeon/required/pkg/lexer"
 
 func Unmarshal(data []byte, v interface{}) error {
-	tokens, err := lexer.Lex(string(data))
-	if err != nil {
-		return err
-	}
-	return Parse(tokens, v)
+	//tokens, err := lexer.Lex(string(data))
+	//if err != nil {
+	//	return err
+	//}
+	return Parse(lexer.NewLexer(string(data)), v)
 }

--- a/pkg/json/unmarshal.go
+++ b/pkg/json/unmarshal.go
@@ -3,13 +3,5 @@ package json
 import "github.com/Pungyeon/required/pkg/lexer"
 
 func Unmarshal(data []byte, v interface{}) error {
-	//tokens, err := lexer.Lex(string(data))
-	//if err != nil {
-	//	return err
-	//}
 	return Parse(lexer.NewLexer(data), v)
-}
-
-func DecodeJSON(data []byte, v interface{}) error {
-	return Decode(lexer.NewLexer(data), v)
 }

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -162,15 +162,14 @@ func (l *lexer) readNumber() (token.Token, error) {
 }
 
 func (l *lexer) readString() (token.Token, error) {
-	var buf []byte
+	start := l.index + 1
 	for l.next() {
 		if l.value() == token.Quotation {
 			return token.Token{
-				Value: string(buf),
+				Value: l.input[start:l.index],
 				Type:  token.String,
 			}, nil
 		}
-		buf = append(buf, l.value())
 	}
 	return token.Token{}, errors.New("unexpected end of file, trying to read string")
 }

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -42,13 +42,23 @@ func (l *Lexer) Current() token.Token {
 }
 
 func (l *Lexer) SkipValue() []byte {
+	if l.index == -1 {
+		l.index = 0
+	}
+	l.skipWhile(':')
 	l.skipWhitespace()
-
 	var (
 		stack   int
 		start   = l.index
 		opening byte
 	)
+	if l.value() == '"' {
+		t, err := l.readString()
+		if err != nil {
+			return nil
+		}
+		return t.Value
+	}
 
 	closing, ok := token.BraceOpposites[l.value()]
 	if !ok {
@@ -69,6 +79,9 @@ func (l *Lexer) SkipValue() []byte {
 			}
 		}
 	}
+	if l.input[start] == '"' {
+
+	}
 
 	if l.input[l.index-1] == '}' {
 		return l.input[start : l.index-1]
@@ -80,7 +93,11 @@ func (l *Lexer) SkipValue() []byte {
 }
 
 func (l *Lexer) skipWhitespace() {
-	for l.value() == ' ' {
+	l.skipWhile(' ')
+}
+
+func (l *Lexer) skipWhile(b byte) {
+	for !l.EOF() && l.value() == b {
 		if !l.next() {
 			return
 		}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -41,6 +41,60 @@ func (l *Lexer) Current() token.Token {
 	return l.current
 }
 
+func (l *Lexer) SkipValue() []byte {
+	l.skipWhitespace()
+
+	var (
+		stack   int
+		start   = l.index
+		opening byte
+	)
+
+	closing, ok := token.BraceOpposites[l.value()]
+	if !ok {
+		closing = ','
+	} else {
+		opening = l.value()
+	}
+
+	for l.next() {
+		if l.value() == opening {
+			stack++
+		}
+		if l.value() == closing {
+			if stack == 0 {
+				return l.input[start : l.index+1]
+			} else {
+				stack--
+			}
+		}
+	}
+
+	if l.input[l.index-1] == '}' {
+		return l.input[start : l.index-1]
+	}
+	if l.index == len(l.input) {
+		return l.input[start:l.index]
+	}
+	return l.input[start : l.index+1]
+}
+
+func (l *Lexer) skipWhitespace() {
+	for l.value() == ' ' {
+		if !l.next() {
+			return
+		}
+	}
+}
+
+func (l *Lexer) skipTo(b byte) {
+	for l.next() {
+		if l.value() == b {
+			return
+		}
+	}
+}
+
 var (
 	TRUE  = []byte("true")
 	FALSE = []byte("false")

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -22,9 +22,9 @@ type ILexer interface {
 	Next() bool
 }
 
-func NewLexer(input string) *Lexer {
+func NewLexer(input []byte) *Lexer {
 	return &Lexer{
-		input: []byte(input),
+		input: input,
 		index: -1,
 	}
 }

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -140,23 +140,21 @@ func (l *lexer) assign(t token.Token) bool {
 
 func (l *lexer) readNumber() (token.Token, error) {
 	tokenType := token.Integer
-	buf := []byte{l.value()}
+	start := l.index
 	for l.next() {
 		switch l.value() {
 		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-			buf = append(buf, l.value())
 		case '.':
 			tokenType = token.Float
-			buf = append(buf, l.value())
 		default:
 			return token.Token{
-				Value: string(buf),
+				Value: l.input[start:l.index],
 				Type:  tokenType,
 			}, nil
 		}
 	}
 	return token.Token{
-		Value: string(buf),
+		Value: l.input[start:l.index],
 		Type:  tokenType,
 	}, nil
 }

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -15,33 +15,33 @@ type Result struct {
 	Error error
 }
 
-type Lexer interface {
+type ILexer interface {
 	EOF() bool
 	Previous() token.Token
 	Current() token.Token
 	Next() bool
 }
 
-func NewLexer(input string) Lexer {
-	return &lexer{
+func NewLexer(input string) *Lexer {
+	return &Lexer{
 		input: input,
 		index: -1,
 	}
 }
 
-func (l *lexer) EOF() bool {
+func (l *Lexer) EOF() bool {
 	return l.index >= len(l.input)
 }
 
-func (l *lexer) Previous() token.Token {
+func (l *Lexer) Previous() token.Token {
 	return l.previous
 }
 
-func (l *lexer) Current() token.Token {
+func (l *Lexer) Current() token.Token {
 	return l.current
 }
 
-func (l *lexer) Next() bool {
+func (l *Lexer) Next() bool {
 	if !l.next() {
 		return false // should be eof error?
 	}
@@ -77,7 +77,7 @@ func (l *lexer) Next() bool {
 }
 
 func Lex(input string) (token.Tokens, error) {
-	l := &lexer{
+	l := &Lexer{
 		input: input,
 		index: -1,
 	}
@@ -115,7 +115,7 @@ func Lex(input string) (token.Tokens, error) {
 	return l.output, nil
 }
 
-type lexer struct {
+type Lexer struct {
 	current  token.Token
 	previous token.Token
 	index    int
@@ -123,22 +123,22 @@ type lexer struct {
 	output   []token.Token
 }
 
-func (l *lexer) next() bool {
+func (l *Lexer) next() bool {
 	l.index++
 	return l.index < len(l.input)
 }
 
-func (l *lexer) value() byte {
+func (l *Lexer) value() byte {
 	return l.input[l.index]
 }
 
-func (l *lexer) assign(t token.Token) bool {
+func (l *Lexer) assign(t token.Token) bool {
 	l.previous = l.current
 	l.current = t
 	return true
 }
 
-func (l *lexer) readNumber() (token.Token, error) {
+func (l *Lexer) readNumber() (token.Token, error) {
 	tokenType := token.Integer
 	start := l.index
 	for l.next() {
@@ -159,7 +159,7 @@ func (l *lexer) readNumber() (token.Token, error) {
 	}, nil
 }
 
-func (l *lexer) readString() (token.Token, error) {
+func (l *Lexer) readString() (token.Token, error) {
 	start := l.index + 1
 	for l.next() {
 		if l.value() == token.Quotation {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -24,7 +24,7 @@ type ILexer interface {
 
 func NewLexer(input string) *Lexer {
 	return &Lexer{
-		input: input,
+		input: []byte(input),
 		index: -1,
 	}
 }
@@ -40,6 +40,12 @@ func (l *Lexer) Previous() token.Token {
 func (l *Lexer) Current() token.Token {
 	return l.current
 }
+
+var (
+	TRUE  = []byte("true")
+	FALSE = []byte("false")
+	NULL  = []byte("null")
+)
 
 func (l *Lexer) Next() bool {
 	if !l.next() {
@@ -63,22 +69,22 @@ func (l *Lexer) Next() bool {
 		return l.assign(t)
 	case 't':
 		l.index += len("rue")
-		l.assign(token.Token{Value: "true", Type: token.Boolean})
+		l.assign(token.Token{Value: TRUE, Type: token.Boolean})
 		return true
 	case 'f':
 		l.index += len("alse")
-		return l.assign(token.Token{Value: "false", Type: token.Boolean})
+		return l.assign(token.Token{Value: FALSE, Type: token.Boolean})
 	case 'n':
 		l.index += len("ull")
-		return l.assign(token.Token{Value: "null", Type: token.Null})
+		return l.assign(token.Token{Value: NULL, Type: token.Null})
 	default:
-		return l.assign(token.NewToken(l.value()))
+		return l.assign(token.NewToken(l.input, l.index))
 	}
 }
 
 func Lex(input string) (token.Tokens, error) {
 	l := &Lexer{
-		input: input,
+		input: []byte(input),
 		index: -1,
 	}
 
@@ -100,16 +106,16 @@ func Lex(input string) (token.Tokens, error) {
 			l.output = append(l.output, t)
 			l.index--
 		case 't':
-			l.output = append(l.output, token.Token{Value: "true", Type: token.Boolean})
+			l.output = append(l.output, token.Token{Value: TRUE, Type: token.Boolean})
 			l.index += len("rue")
 		case 'f':
-			l.output = append(l.output, token.Token{Value: "false", Type: token.Boolean})
+			l.output = append(l.output, token.Token{Value: FALSE, Type: token.Boolean})
 			l.index += len("alse")
 		case 'n':
-			l.output = append(l.output, token.Token{Value: "null", Type: token.Null})
+			l.output = append(l.output, token.Token{Value: NULL, Type: token.Null})
 			l.index += len("ull")
 		default:
-			l.output = append(l.output, token.NewToken(l.value()))
+			l.output = append(l.output, token.NewToken(l.input, l.index))
 		}
 	}
 	return l.output, nil
@@ -119,7 +125,7 @@ type Lexer struct {
 	current  token.Token
 	previous token.Token
 	index    int
-	input    string
+	input    []byte
 	output   []token.Token
 }
 

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -3,6 +3,7 @@ package lexer
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -28,7 +29,6 @@ func TestScanValue(t *testing.T) {
 	"float": 3.2
 }`))
 	lexer.skipTo(':')
-	lexer.next()
 	val := lexer.SkipValue()
 
 	if string(val) != `{
@@ -37,10 +37,8 @@ func TestScanValue(t *testing.T) {
 		t.Fatal(string(val))
 	}
 	lexer.skipTo(':')
-	lexer.next()
 
 	fmt.Println(string(lexer.input[lexer.index:]))
-	fmt.Println("here we are")
 
 	val = lexer.SkipValue()
 
@@ -49,6 +47,17 @@ func TestScanValue(t *testing.T) {
 		t.Fatal(err)
 	}
 	if floaty != 3.2 {
+		t.Fatal(string(val))
+	}
+
+	lexer = NewLexer([]byte(`{
+		"value": "2006-01-02T15:04:05"
+	}`))
+
+	lexer.skipTo(':')
+
+	val = lexer.SkipValue()
+	if strings.TrimSpace(string(val)) != "2006-01-02T15:04:05" {
 		t.Fatal(string(val))
 	}
 }

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -30,7 +30,7 @@ func BenchmarkLexerPerformance(b *testing.B) {
 
 func BenchmarkLexerStreamPerformance(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		l := NewLexer(`{"foo": [1, 2, {"bar": 2}, true]}`)
+		l := NewLexer([]byte(`{"foo": [1, 2, {"bar": 2}, true]}`))
 		for l.Next() {
 			_ = l.Current()
 		}

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -17,3 +17,22 @@ func TestLexer(t *testing.T) {
 		t.Fatalf("%v != %v", result, expected)
 	}
 }
+
+func BenchmarkLexerPerformance(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		tokens, err := Lex(`{"foo": [1, 2, {"bar": 2}, true]}`)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = tokens
+	}
+}
+
+func BenchmarkLexerStreamPerformance(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		l := NewLexer(`{"foo": [1, 2, {"bar": 2}, true]}`)
+		for l.Next() {
+			_ = l.Current()
+		}
+	}
+}

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -1,6 +1,8 @@
 package lexer
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -15,6 +17,39 @@ func TestLexer(t *testing.T) {
 
 	if result != expected {
 		t.Fatalf("%v != %v", result, expected)
+	}
+}
+
+func TestScanValue(t *testing.T) {
+	lexer := NewLexer([]byte(`{
+	"foo": {
+		"bar": "value" 
+	},
+	"float": 3.2
+}`))
+	lexer.skipTo(':')
+	lexer.next()
+	val := lexer.SkipValue()
+
+	if string(val) != `{
+		"bar": "value" 
+	}` {
+		t.Fatal(string(val))
+	}
+	lexer.skipTo(':')
+	lexer.next()
+
+	fmt.Println(string(lexer.input[lexer.index:]))
+	fmt.Println("here we are")
+
+	val = lexer.SkipValue()
+
+	var floaty float64
+	if err := json.Unmarshal(val, &floaty); err != nil {
+		t.Fatal(err)
+	}
+	if floaty != 3.2 {
+		t.Fatal(string(val))
 	}
 }
 

--- a/pkg/required/error.go
+++ b/pkg/required/error.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	ErrCannotUnmarshal  = fmt.Errorf("json: cannot unmarshal given value")
-	ErrEmpty            = errors.New("type of required.Required not allowed to be empty")
+	ErrEmpty            = errors.New("type of required.RequiredInterface not allowed to be empty")
 	ErrEmptyBool        = errors.New("type of required.Bool not allowed to be empty")
 	ErrEmptyBoolSlice   = errors.New("type of required.BoolSlice not allowed to be empty")
 	ErrEmptyByteSlice   = errors.New("type of required.ByteSlice not allowed to be empty")

--- a/pkg/required/required.go
+++ b/pkg/required/required.go
@@ -10,7 +10,7 @@ type Nullable struct {
 	value interface{}
 }
 
-// Required is an interface which will enable the require.Unmarshal parser,
+// Required is an interface which will enable the require.UnmarshalInterface parser,
 // to check whether a given object / interface has a valid contained value.
 type Required interface {
 	IsValueValid() error
@@ -27,7 +27,7 @@ func ReturnIfError(errs ...error) error {
 	return nil
 }
 
-// Unmarshal is a wrapping function of the json.Unmarshal function
+// Unmarshal is a wrapping function of the json.UnmarshalInterface function
 func Unmarshal(data []byte, v interface{}) error {
 	return ReturnIfError(
 		json.Unmarshal(data, v),

--- a/pkg/structtag/error.go
+++ b/pkg/structtag/error.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	errRequiredField = errors.New("required field missing")
+	errRequiredField = errors.New("RequiredInterface field missing")
 )
 
 func IsRequiredErr(err error) bool {

--- a/pkg/structtag/structtag.go
+++ b/pkg/structtag/structtag.go
@@ -5,11 +5,12 @@ import (
 )
 
 type Tag struct {
-	FieldIndex  int
-	FieldName   string
-	Required    bool
-	OmitIfEmpty bool
-	IsSet       bool
+	FieldIndex        int
+	FieldName         string
+	Required          bool
+	OmitIfEmpty       bool
+	IsSet             bool
+	RequiredInterface bool
 }
 
 func (t *Tag) addValue(value string) error {

--- a/pkg/structtag/tags.go
+++ b/pkg/structtag/tags.go
@@ -47,26 +47,28 @@ func FromValue(vo reflect.Value) (Tags, error) {
 	}
 
 	tags := Tags(make(map[string]Tag))
+	if vo.CanSet() {
 
-	var ok bool
-	if vo.CanAddr() {
-		_, ok = vo.Addr().Interface().(required.Required)
-	} else {
-		_, ok = vo.Interface().(required.Required)
-	}
-	tags[RequiredInterfaceKey] = Tag{
-		FieldIndex: -1,
-		Required:   ok,
-	}
+		var ok bool
+		if vo.CanAddr() {
+			_, ok = vo.Addr().Interface().(required.Required)
+		} else {
+			_, ok = vo.Interface().(required.Required)
+		}
+		tags[RequiredInterfaceKey] = Tag{
+			FieldIndex: -1,
+			Required:   ok,
+		}
 
-	if vo.CanAddr() {
-		_, ok = vo.Addr().Interface().(json.Unmarshaler)
-	} else {
-		_, ok = vo.Interface().(json.Unmarshaler)
-	}
-	tags[UnmarshalInterfaceKey] = Tag{
-		FieldIndex: -1,
-		Required:   ok,
+		if vo.CanAddr() {
+			_, ok = vo.Addr().Interface().(json.Unmarshaler)
+		} else {
+			_, ok = vo.Interface().(json.Unmarshaler)
+		}
+		tags[UnmarshalInterfaceKey] = Tag{
+			FieldIndex: -1,
+			Required:   ok,
+		}
 	}
 	if vo.Kind() != reflect.Struct {
 		cache[vo.Type()] = tags

--- a/pkg/structtag/tags.go
+++ b/pkg/structtag/tags.go
@@ -31,7 +31,7 @@ func FromValue(vo reflect.Value) (Tags, error) {
 	}
 
 	// TODO : @pungyeon - This is currently not thread safe. A mutex lock or channel is therefore needed, to ensure no race conditions are met. The reason for this cache implementation, is for general performance. This accounts for a lot of allocations, and since this is static on compilation, we can guarantee that this will never change. Therefore, the cache is a good place to start.
-	// TODO : @pungyeon - On further thought, this might actually break functionality!
+	// TODO : @pungyeon - On further thought this breaks functionality completely :|!
 	if tags, ok := cache[vo.Type()]; ok {
 		return tags, nil
 	}

--- a/pkg/structtag/tags.go
+++ b/pkg/structtag/tags.go
@@ -1,12 +1,17 @@
 package structtag
 
 import (
+	"encoding/json"
+	"fmt"
 	"reflect"
 
 	"github.com/Pungyeon/required/pkg/required"
 )
 
-var RequiredInterfaceKey = "__IRQ__"
+var (
+	RequiredInterfaceKey  = "__IRQ__"
+	UnmarshalInterfaceKey = "__IUM__"
+)
 var cache = map[reflect.Type]Tags{}
 
 type Tags map[string]Tag
@@ -46,10 +51,16 @@ func FromValue(vo reflect.Value) (Tags, error) {
 	}
 
 	tags := Tags(make(map[string]Tag))
-	_, req := vo.Interface().(required.Required)
+	_, ok := vo.Interface().(required.Required)
 	tags[RequiredInterfaceKey] = Tag{
 		FieldIndex: -1,
-		Required:   req,
+		Required:   ok,
+	}
+	_, ok = vo.Interface().(json.Unmarshaler)
+	fmt.Println("can marshal:", ok, vo.Type())
+	tags[UnmarshalInterfaceKey] = Tag{
+		FieldIndex: -1,
+		Required:   ok,
 	}
 	for i := 0; i < vo.NumField(); i++ {
 		f := vo.Type().Field(i)

--- a/pkg/structtag/tags.go
+++ b/pkg/structtag/tags.go
@@ -15,15 +15,19 @@ var (
 // TODO : @pungyeon - This is currently not thread safe. A mutex lock or channel is therefore needed, to ensure no race conditions are met. The reason for this cache implementation, is for general performance. This accounts for a lot of allocations, and since this is static on compilation, we can guarantee that this will never change. Therefore, the cache is a good place to start.
 var cache = map[reflect.Type]Tags{}
 
-type Tags map[string]Tag
+type Tags struct {
+	RequiredInterface  bool
+	UnmarshalInterface bool
+	Tags               map[string]Tag
+}
 
 func (tags Tags) Set(tag Tag) {
 	tag.IsSet = true
-	tags[tag.FieldName] = tag
+	tags.Tags[tag.FieldName] = tag
 }
 
 func (tags Tags) CheckRequired() error {
-	for _, tag := range tags {
+	for _, tag := range tags.Tags {
 		if tag.Required && !tag.IsSet {
 			return requiredErr{
 				err:   errRequiredField,
@@ -35,7 +39,7 @@ func (tags Tags) CheckRequired() error {
 }
 
 func (tags Tags) Reset() {
-	for _, tag := range tags {
+	for _, tag := range tags.Tags {
 		tag.IsSet = false
 	}
 }
@@ -46,28 +50,14 @@ func FromValue(vo reflect.Value) (Tags, error) {
 		return tags, nil
 	}
 
-	tags := Tags(make(map[string]Tag))
+	tags := Tags{Tags: make(map[string]Tag)}
 	if vo.CanSet() {
-
-		var ok bool
 		if vo.CanAddr() {
-			_, ok = vo.Addr().Interface().(required.Required)
+			_, tags.RequiredInterface = vo.Addr().Interface().(required.Required)
+			_, tags.UnmarshalInterface = vo.Addr().Interface().(json.Unmarshaler)
 		} else {
-			_, ok = vo.Interface().(required.Required)
-		}
-		tags[RequiredInterfaceKey] = Tag{
-			FieldIndex: -1,
-			Required:   ok,
-		}
-
-		if vo.CanAddr() {
-			_, ok = vo.Addr().Interface().(json.Unmarshaler)
-		} else {
-			_, ok = vo.Interface().(json.Unmarshaler)
-		}
-		tags[UnmarshalInterfaceKey] = Tag{
-			FieldIndex: -1,
-			Required:   ok,
+			_, tags.RequiredInterface = vo.Interface().(required.Required)
+			_, tags.UnmarshalInterface = vo.Interface().(json.Unmarshaler)
 		}
 	}
 	if vo.Kind() != reflect.Struct {
@@ -79,16 +69,16 @@ func FromValue(vo reflect.Value) (Tags, error) {
 		f := vo.Type().Field(i)
 		jsonTag, ok := f.Tag.Lookup("json")
 		if !ok {
-			tags[toSnakeCase(f.Name)] = Tag{
+			tags.Tags[toSnakeCase(f.Name)] = Tag{
 				FieldIndex: i,
 				FieldName:  f.Name,
 			}
 		} else {
 			tag, err := fromString(jsonTag, i)
 			if err != nil {
-				return nil, err
+				return tags, err
 			}
-			tags[tag.FieldName] = tag
+			tags.Tags[tag.FieldName] = tag
 		}
 	}
 	cache[vo.Type()] = tags

--- a/pkg/structtag/tags_test.go
+++ b/pkg/structtag/tags_test.go
@@ -8,7 +8,7 @@ import (
 type TagTest struct {
 	Name     string
 	DingDong string
-	Age      int64 `json:"age,required"`
+	Age      int64 `json:"age,RequiredInterface"`
 }
 
 func TestTagFormatting(t *testing.T) {

--- a/pkg/structtag/tags_test.go
+++ b/pkg/structtag/tags_test.go
@@ -8,7 +8,7 @@ import (
 type TagTest struct {
 	Name     string
 	DingDong string
-	Age      int64 `json:"age,RequiredInterface"`
+	Age      int64 `json:"age,required"`
 }
 
 func TestTagFormatting(t *testing.T) {
@@ -21,11 +21,11 @@ func TestTagFormatting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := tags["name"]; !ok {
+	if _, ok := tags.Tags["name"]; !ok {
 		t.Fatal(`could not find "name" tag`)
 	}
 
-	dingDong, ok := tags["ding_dong"]
+	dingDong, ok := tags.Tags["ding_dong"]
 	if !ok {
 		t.Fatal(`could not find "ding_dong" tag`)
 	}
@@ -33,7 +33,7 @@ func TestTagFormatting(t *testing.T) {
 		t.Fatal("unexpected field_index for ding_dong:", dingDong.FieldIndex)
 	}
 
-	age, ok := tags["age"]
+	age, ok := tags.Tags["age"]
 	if !ok {
 		t.Fatal(`could not find "age" tag`)
 	}

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -210,7 +210,7 @@ func (token Token) IsEnding() bool {
 }
 
 func (token Token) String() string {
-	return string(token.Value) + ": " + string(token.Type)
+	return fmt.Sprintf("%s: %d", token.Value, token.Type)
 }
 
 func (token Token) ToString() string {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -125,6 +125,37 @@ func (token Token) AsValue(vt reflect.Type) (reflect.Value, error) {
 	}
 }
 
+func (token Token) SetValueOf(val reflect.Value) error {
+	switch token.Type {
+	case String:
+		val.SetString(token.Value.(string))
+		return nil
+	case Integer:
+		n, err := strconv.ParseInt(token.Value.(string), 10, 64)
+		if err != nil {
+			return err
+		}
+		val.SetInt(n)
+		return err
+	case Float:
+		f, err := strconv.ParseFloat(token.Value.(string), 64)
+		if err != nil {
+			return err
+		}
+		val.SetFloat(f)
+		return err
+	case Boolean:
+		if token.Value.(string)[0] == 't' {
+			val.SetBool(true)
+		} else {
+			val.SetBool(false)
+		}
+		return nil
+	default:
+		return fmt.Errorf("cannot convert token to value: %v", token)
+	}
+}
+
 func (token Token) ToValue() (reflect.Value, error) {
 	switch token.Type {
 	case String:

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -173,9 +173,17 @@ type Tokens []Token
 func (tokens Tokens) Join(sep string) string {
 	var buf bytes.Buffer
 	for i, token := range tokens {
-		buf.WriteString(token.Value.(string))
-		if i < len(tokens)-1 {
-			buf.WriteString(sep)
+		switch token.Value.(type) {
+		case string:
+			buf.WriteString(token.Value.(string))
+			if i < len(tokens)-1 {
+				buf.WriteString(sep)
+			}
+		case byte:
+			buf.WriteString(string(token.Value.(byte)))
+			if i < len(tokens)-1 {
+				buf.WriteString(sep)
+			}
 		}
 	}
 	return buf.String()

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -135,6 +135,9 @@ func (token Token) AsValue(vt reflect.Type) (reflect.Value, error) {
 }
 
 func (token Token) SetValueOf(val reflect.Value) error {
+	if !val.CanSet() {
+		return nil
+	}
 	switch token.Type {
 	case Null:
 		return nil // don't set anything

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -49,42 +49,42 @@ const (
 	Boolean        TokenType = "BOOLEAN"
 )
 
-var TokenTypes = map[string]TokenType{
-	"UNKNOWN":    Unknown,
-	"BOOLEAN":    Boolean,
-	"INTEGER":    Integer,
-	"FLOAT":      Float,
-	"STRING":     String,
-	"NULL":       Null,
-	"KEY_TOKEN":  Key,
-	":":          Colon,
-	",":          Comma,
-	"WHITESPACE": WhiteSpace,
-	"[":          OpenBrace,
-	"]":          ClosingBrace,
-	"(":          OpenBracket,
-	")":          ClosingBracket,
-	"{":          OpenCurly,
-	"}":          ClosingCurly,
-	".":          FullStop,
+var TokenTypes = map[byte]TokenType{
+	// "UNKNOWN":    Unknown,
+	// "BOOLEAN":    Boolean,
+	// "INTEGER":    Integer,
+	// "FLOAT":      Float,
+	// "STRING":     String,
+	// "NULL":       Null,
+	// "KEY_TOKEN":  Key,
+	// "WHITESPACE": WhiteSpace,
+	':': Colon,
+	',': Comma,
+	'[': OpenBrace,
+	']': ClosingBrace,
+	'(': OpenBracket,
+	')': ClosingBracket,
+	'{': OpenCurly,
+	'}': ClosingCurly,
+	'.': FullStop,
 }
 
 type Token struct {
-	Value string
+	Value interface{}
 	Type  TokenType
 }
 
 func NewToken(b byte) Token {
-	t, ok := TokenTypes[string(b)]
+	t, ok := TokenTypes[b]
 	if !ok {
 
 		return Token{
-			Value: string(b),
+			Value: b,
 			Type:  Unknown,
 		}
 	}
 	return Token{
-		Value: string(b),
+		Value: b,
 		Type:  t,
 	}
 }
@@ -97,24 +97,24 @@ func (token Token) AsValue(vt reflect.Type) (reflect.Value, error) {
 	val := reflect.New(vt).Elem()
 	switch token.Type {
 	case String:
-		val.SetString(token.Value)
+		val.SetString(token.Value.(string))
 		return val, nil
 	case Integer:
-		n, err := strconv.ParseInt(token.Value, 10, 64)
+		n, err := strconv.ParseInt(token.Value.(string), 10, 64)
 		if err != nil {
 			return val, err
 		}
 		val.SetInt(n)
 		return val, err
 	case Float:
-		f, err := strconv.ParseFloat(token.Value, 64)
+		f, err := strconv.ParseFloat(token.Value.(string), 64)
 		if err != nil {
 			return val, err
 		}
 		val.SetFloat(f)
 		return val, err
 	case Boolean:
-		if token.Value[0] == 't' {
+		if token.Value.(string)[0] == 't' {
 			val.SetBool(true)
 		} else {
 			val.SetBool(false)
@@ -129,11 +129,11 @@ func (token Token) ToValue() (reflect.Value, error) {
 	switch token.Type {
 	case String:
 		val := reflect.New(ReflectTypeString).Elem()
-		val.SetString(token.Value)
+		val.SetString(token.Value.(string))
 		return val, nil
 	case Integer:
 		val := reflect.New(ReflectTypeInteger).Elem()
-		n, err := strconv.ParseInt(token.Value, 10, 64)
+		n, err := strconv.ParseInt(token.Value.(string), 10, 64)
 		if err != nil {
 			return val, err
 		}
@@ -141,7 +141,7 @@ func (token Token) ToValue() (reflect.Value, error) {
 		return val, err
 	case Float:
 		val := reflect.New(ReflectTypeFloat).Elem()
-		f, err := strconv.ParseFloat(token.Value, 64)
+		f, err := strconv.ParseFloat(token.Value.(string), 64)
 		if err != nil {
 			return val, err
 		}
@@ -149,7 +149,7 @@ func (token Token) ToValue() (reflect.Value, error) {
 		return val, err
 	case Boolean:
 		val := reflect.New(ReflectTypeBool).Elem()
-		if token.Value[0] == 't' {
+		if token.Value.(string)[0] == 't' {
 			val.SetBool(true)
 		} else {
 			val.SetBool(false)
@@ -165,7 +165,7 @@ func (token Token) IsEnding() bool {
 }
 
 func (token Token) String() string {
-	return token.Value + ": " + string(token.Type)
+	return token.Value.(string) + ": " + string(token.Type)
 }
 
 type Tokens []Token
@@ -173,7 +173,7 @@ type Tokens []Token
 func (tokens Tokens) Join(sep string) string {
 	var buf bytes.Buffer
 	for i, token := range tokens {
-		buf.WriteString(token.Value)
+		buf.WriteString(token.Value.(string))
 		if i < len(tokens)-1 {
 			buf.WriteString(sep)
 		}

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -22,7 +22,7 @@ var (
 	ReflectTypeBool      = reflect.TypeOf(true)
 )
 
-type TokenType string
+type TokenType int
 
 func (t TokenType) IsEnding() bool {
 	return t == ClosingBrace || t == ClosingCurly ||
@@ -30,23 +30,23 @@ func (t TokenType) IsEnding() bool {
 }
 
 const (
-	Unknown        TokenType = "UNKNOWN"
-	Integer        TokenType = "INTEGER"
-	Float          TokenType = "FLOAT"
-	String         TokenType = "STRING"
-	Null           TokenType = "NULL"
-	Key            TokenType = "KEY_TOKEN"
-	Colon          TokenType = ":"
-	Comma          TokenType = ","
-	WhiteSpace     TokenType = "WHITESPACE"
-	OpenBrace      TokenType = "["
-	ClosingBrace   TokenType = "]"
-	OpenBracket    TokenType = "("
-	ClosingBracket TokenType = ")"
-	OpenCurly      TokenType = "{"
-	ClosingCurly   TokenType = "}"
-	FullStop       TokenType = "."
-	Boolean        TokenType = "BOOLEAN"
+	Unknown TokenType = iota
+	Integer
+	Float
+	String
+	Null
+	Key
+	Colon
+	Comma
+	WhiteSpace
+	OpenBrace
+	ClosingBrace
+	OpenBracket
+	ClosingBracket
+	OpenCurly
+	ClosingCurly
+	FullStop
+	Boolean
 )
 
 var TokenTypes = map[byte]TokenType{

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -69,6 +69,15 @@ var TokenTypes = map[byte]TokenType{
 	'.': FullStop,
 }
 
+var BraceOpposites = map[byte]byte{
+	'[': ']',
+	']': '[',
+	'(': ')',
+	')': '(',
+	'{': '}',
+	'}': '{',
+}
+
 type Token struct {
 	Value []byte
 	Type  TokenType

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -77,6 +77,7 @@ type Token struct {
 func NewToken(b byte) Token {
 	t, ok := TokenTypes[string(b)]
 	if !ok {
+
 		return Token{
 			Value: string(b),
 			Type:  Unknown,

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -136,6 +136,8 @@ func (token Token) AsValue(vt reflect.Type) (reflect.Value, error) {
 
 func (token Token) SetValueOf(val reflect.Value) error {
 	switch token.Type {
+	case Null:
+		return nil // don't set anything
 	case String:
 		val.SetString(token.ToString())
 		return nil


### PR DESCRIPTION
This pull request is primarily concerned with fixing #5 

Here are the benchmarks from `v0.2`:
```
goos: darwin
goarch: amd64
pkg: github.com/Pungyeon/required/pkg/json
BenchmarkStdUnmarshal-8           148515              7747 ns/op            1344 B/op      26 allocs/op
BenchmarkPkgUnmarshal-8            57804             20503 ns/op           17037 B/op     267 allocs/op
PASS
ok      github.com/Pungyeon/required/pkg/json   3.077s
```

The highlights being ~x3 worse performance than the std library marshaler and more than x10 the memory consumption (and memory allocations). Even though the code was quite nice, the performance was unfortunately horrendous. After the optimisations of this pull request, we see the following results:

```
goos: darwin
goarch: amd64
pkg: github.com/Pungyeon/required/pkg/json
BenchmarkStdUnmarshal-8           149682              7784 ns/op            1344 B/op      26 allocs/op
BenchmarkPkgUnmarshal-8           155384              7684 ns/op            1512 B/op      34 allocs/op
PASS
ok      github.com/Pungyeon/required/pkg/json   2.941s
```

These results are much more convincing. I have tried my best to find the last 8 allocations and get rid of them, but it seems that the approach is just different. Either way, it looks like they are quite even in speed, as well as memory consumption. This is great 🎉 

Furthermore, I have also implemented support of custom json marshaling (by extending the std lib `json.Unmarshaler` interface).... 

> NOTE: Perhaps I should have included my own version of this in the codebase? 🤷 

There are also a few bugs which have been fixed, such as:
* Private fields are ignored (rather than causing a panic)
* Pointers and Interface types are now parsed in a much nicer manner
* There is no longer any `string` -> `[]byte` conversion in the Unmarshalling of the json, making this a lot closer to std library functionality.

Unfortunately, this performance optimisation has made the code quality suffer quite significantly 😬 However, it's still more understandable than the code in the std library 😅  So I'll let it pass for now.
