### PR TITLE
using array for indexing token types instead of map, for faster access

### DIFF
--- a/pkg/structtag/tags.go
+++ b/pkg/structtag/tags.go
@@ -7,11 +7,6 @@ import (
 	"github.com/Pungyeon/required/pkg/required"
 )
 
-var (
-	RequiredInterfaceKey  = "__IRQ__"
-	UnmarshalInterfaceKey = "__IUM__"
-)
-
 // TODO : @pungyeon - This is currently not thread safe. A mutex lock or channel is therefore needed, to ensure no race conditions are met. The reason for this cache implementation, is for general performance. This accounts for a lot of allocations, and since this is static on compilation, we can guarantee that this will never change. Therefore, the cache is a good place to start.
 var cache = map[reflect.Type]Tags{}
 

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -49,25 +49,31 @@ const (
 	Boolean
 )
 
-var TokenTypes = map[byte]TokenType{
-	// "UNKNOWN":    Unknown,
-	// "BOOLEAN":    Boolean,
-	// "INTEGER":    Integer,
-	// "FLOAT":      Float,
-	// "STRING":     String,
-	// "NULL":       Null,
-	// "KEY_TOKEN":  Key,
-	// "WHITESPACE": WhiteSpace,
-	':': Colon,
-	',': Comma,
-	'[': OpenBrace,
-	']': ClosingBrace,
-	'(': OpenBracket,
-	')': ClosingBracket,
-	'{': OpenCurly,
-	'}': ClosingCurly,
-	'.': FullStop,
+func init() {
+	TokenTypes[':'] = Colon
+	TokenTypes[','] = Comma
+	TokenTypes['['] = OpenBrace
+	TokenTypes[']'] = ClosingBrace
+	TokenTypes['('] = OpenBracket
+	TokenTypes[')'] = ClosingBracket
+	TokenTypes['{'] = OpenCurly
+	TokenTypes['}'] = ClosingCurly
+	TokenTypes['.'] = FullStop
 }
+
+var TokenTypes = make([]TokenType, 126)
+
+//var TokenTypes = map[byte]TokenType{
+//	':': Colon,
+//	',': Comma,
+//	'[': OpenBrace,
+//	']': ClosingBrace,
+//	'(': OpenBracket,
+//	')': ClosingBracket,
+//	'{': OpenCurly,
+//	'}': ClosingCurly,
+//	'.': FullStop,
+//}
 
 var BraceOpposites = map[byte]byte{
 	'[': ']',
@@ -84,17 +90,9 @@ type Token struct {
 }
 
 func NewToken(b []byte, i int) Token {
-	t, ok := TokenTypes[b[i]]
-	if !ok {
-
-		return Token{
-			Value: b[i : i+1], // should we even allocate here?
-			Type:  Unknown,
-		}
-	}
 	return Token{
-		Value: b[i : i+1],
-		Type:  t,
+		Value: b[i : i+1], // should we even allocate here?
+		Type:  TokenTypes[b[i]],
 	}
 }
 


### PR DESCRIPTION
Pretty self explanatory