### PR TITLE
fix bug for non-existing fields

### DIFF
--- a/pkg/json/parser.go
+++ b/pkg/json/parser.go
@@ -141,7 +141,14 @@ func (p *parser) decodeObject(val reflect.Value, tags structtag.Tags) error {
 		if err := p.next(); err != nil {
 			return checkIfEOF(err)
 		}
-		tag := tags.Tags[field.ToString()]
+		tag, ok := tags.Tags[field.ToString()]
+		if !ok {
+			p.lexer.SkipValue()
+			if err := p.next(); err != nil {
+				return checkIfEOF(err)
+			}
+			continue
+		}
 		if err := p.decode(val.Field(tag.FieldIndex)); err != nil {
 			return checkIfEOF(err)
 		}
@@ -386,7 +393,7 @@ func (p *parser) parseStructure(vo reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	// Ignore the field, as it's not definted on the given structure
+	// Ignore the field, as it's not defined on the given structure
 	if len(tags.Tags) == 0 {
 		return nil
 	}

--- a/pkg/json/parser_test.go
+++ b/pkg/json/parser_test.go
@@ -647,10 +647,12 @@ func TestEscapedCharacters(t *testing.T) {
 
 func TestNonExistingField(t *testing.T) {
 	var c C
-	lex := LexString(t, `{"ding": 3}`)
+
+	lex := LexString(t, `{"ding": 3, "data": { "number": 5 }}`)
 	if err := Parse(lex, &c); err != nil {
 		t.Fatal(err)
 	}
+
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -658,7 +660,9 @@ func TestNonExistingField(t *testing.T) {
 		}
 	}()
 
-	fmt.Println(c)
+	if c.Data["number"] != 5 {
+		t.Fatal(c.Data)
+	}
 }
 
 type C struct {


### PR DESCRIPTION
The following input
```
{"ding": 3, "data": { "number": 5 }}
```

With given struct
```
{ 
  Data map[string]interface{}
}
```

Would result in
```
{ Data: map[ "data": { "number": 5 } ] }
```

This PR fixes this issue